### PR TITLE
Containers

### DIFF
--- a/endpoints/README.md
+++ b/endpoints/README.md
@@ -6,6 +6,7 @@ Details on how to setup a Globus Compute endpoint can be found [here](https://fu
 Templates for ALCF machines:
 - [polaris-gpu-config.yaml](polaris-gpu-config.yaml): an endpoint config that will set up 4 workers per node and assign 1 gpu and 4 cpu hardware threads per worker.
 - [polaris-cpu-config.yaml](polaris-cpu-config.yaml): an endpoint config that will setup 32 workers per node and assign 1 cpu core per worker
+- [polaris-apptainer-config.yaml](polaris-apptainer-config.yaml): an endpoint config that will spin up an Apptainer container
 
 To use a template first edit it to include your project name, initialization commands, etc.  Then to configure the endpoint:
 

--- a/endpoints/polaris-apptainer-config.yaml
+++ b/endpoints/polaris-apptainer-config.yaml
@@ -1,0 +1,44 @@
+# This configuration file provides an example on how to run an Apptainer container
+# on a compute node on Polaris. When the node is acquired, the container will be 
+# started, and incoming Globus Compute tasks will be executed directly within the
+# running container.
+amqp_port: 443
+display_name: PolarisApptainer
+engine:
+  max_workers_per_node: 1
+  container_type: apptainer
+  container_uri: <PLACEHOLDER --> /full/path/to/your/.sing-or-.sif-file>
+  container_cmd_options: --fakeroot
+  provider:
+    type: PBSProProvider
+    launcher:
+      type: SimpleLauncher
+    account: IRIBeta
+    cpus_per_node: 64
+    select_options: ngpus=0
+    scheduler_options: '#PBS -l filesystems=home:eagle'
+    queue: debug
+    init_blocks: 0
+    max_blocks: 1
+    min_blocks: 0
+    nodes_per_block: 1
+    walltime: 01:00:00
+    worker_init: |
+      ml use /soft/modulefiles
+      ml spack-pe-base/0.8.1
+      ml use /soft/spack/testing/0.8.1/modulefiles
+      ml apptainer/main
+      ml load e2fsprogs
+      export BASE_SCRATCH_DIR=/local/scratch/
+      export APPTAINER_TMPDIR=$BASE_SCRATCH_DIR/apptainer-tmpdir
+      mkdir -p $APPTAINER_TMPDIR
+      export APPTAINER_CACHEDIR=$BASE_SCRATCH_DIR/apptainer-cachedir
+      mkdir -p $APPTAINER_CACHEDIR
+      export HTTP_PROXY=http://proxy.alcf.anl.gov:3128
+      export HTTPS_PROXY=http://proxy.alcf.anl.gov:3128
+      export http_proxy=http://proxy.alcf.anl.gov:3128
+      export https_proxy=http://proxy.alcf.anl.gov:3128
+      module unload xalt
+  type: GlobusComputeEngine
+#allowed_functions:
+#   - <PLACEHOLDER --> your registered function UUID>

--- a/endpoints/polaris-apptainer-config.yaml
+++ b/endpoints/polaris-apptainer-config.yaml
@@ -2,6 +2,19 @@
 # on a compute node on Polaris. When the node is acquired, the container will be 
 # started, and incoming Globus Compute tasks will be executed directly within the
 # running container.
+#
+# Note: The globus-compute-endpoint package must be baked into the container image
+#       in order for Globus Compute to communicate with the running container. Below
+#       is an example of how the installation was added to the LSST/DESC Dockerfile:
+#
+#       # Install Globus Compute endpoint system-wide (not inside lsst environment to avoid interfering with dependencies)
+#       # Only needed when Globus Compute directly executes functions within the container
+#       USER root
+#       RUN dnf install -y python3 python3-pip && \
+#           dnf clean all
+#       RUN pip3 install globus-compute-endpoint
+#       USER lsst
+
 amqp_port: 443
 display_name: PolarisApptainer
 engine:

--- a/functions/register_apptainer_function.py
+++ b/functions/register_apptainer_function.py
@@ -1,0 +1,75 @@
+import globus_compute_sdk
+
+# Test function when workers are deployed outside of the container.
+# This is an alternative to executing functions directly within
+# running containers. If the science teams come with already-built 
+# container images, this approach allows them to preverse their images.
+# Otherwise, they would need to re-build them include Globus Compute.
+#
+# Below was an example to run the LSST/DESC environment.
+def test(sif_sing_path=None):
+    """
+    Test function that will load the LSST/Desc environment and print
+    the location of the python executable from within the container.
+    
+    Argument
+    --------
+        sif_sing_path (str): Full path to the Apptainer .sif or .sing file
+    """
+
+    # Import the necessary python packages
+    import subprocess
+
+    # Make sure the sif_sing_path is a string
+    if not isinstance(sif_sing_path, str):
+        return "Error: 'sif_sing_path' parameter should be provided as a string."
+
+    # Define all commands that need to be executed in the container
+    # This needs to be hardcoded or vetted (no arbitrary code execution)
+    commands = """
+    source /opt/lsst/software/stack/loadLSST.bash
+    setup lsst_distrib
+    eups list lsst_distrib
+    command -v python
+    """
+
+    # Define subprocess arguments
+    kwargs = {
+        "shell": True, 
+        "check": True,
+        "text": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "executable": "/bin/bash"
+    }
+
+    # Define the Apptainer command to be executed on the compute node
+    one_line_command = " && ".join(line.strip() for line in commands.strip().splitlines() if line.strip())
+    apptainer_command = f"apptainer exec --fakeroot {sif_sing_path} bash -c '{one_line_command}'"
+
+    # Execute the command lines
+    try:
+        result = subprocess.run(apptainer_command, **kwargs)
+    except subprocess.CalledProcessError as e:
+        return f"Error: {e}"
+        
+    # Return command line output
+    return result.stdout
+
+
+# Creating Globus Compute client
+gcc = globus_compute_sdk.Client()
+
+# # Register the function
+COMPUTE_FUNCTION_ID = gcc.register_function(test)
+
+# # Write function UUID in a file
+uuid_file_name = "uuid_test_function.txt"
+with open(uuid_file_name, "w") as file:
+    file.write(COMPUTE_FUNCTION_ID)
+    file.write("\n")
+file.close()
+
+# # End of script
+print(f"\Function registered with UUID - {COMPUTE_FUNCTION_ID}")
+print(f"The UUID is stored in {uuid_file_name}.\n")


### PR DESCRIPTION
Suggesting two new files related to running Apptainer with Globus Compute on Polaris:
1. Config file for when Globus Compute tasks need to be executed directly within a running container (parsl workers deployed within the container).
2. Compute function example when parsl workers are deployed outside of the container (the function runs an apptainer command line as a subprocess).